### PR TITLE
Add PR merge functionality to Focus Mode detail panel

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -2686,6 +2686,60 @@ body,
   background: var(--bg-primary);
   display: flex;
   justify-content: flex-end;
+  gap: 8px;
+}
+
+/* Merge Container */
+.pr-merge-container {
+  position: relative;
+}
+
+.pr-merge-dropdown {
+  position: absolute;
+  bottom: 100%;
+  right: 0;
+  margin-bottom: 4px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  min-width: 280px;
+  z-index: 100;
+  overflow: hidden;
+}
+
+.pr-merge-option {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 100%;
+  padding: 12px 14px;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+  text-align: left;
+}
+
+.pr-merge-option:last-child {
+  border-bottom: none;
+}
+
+.pr-merge-option:hover {
+  background: var(--bg-hover);
+}
+
+.pr-merge-option-title {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-primary);
+  margin-bottom: 4px;
+}
+
+.pr-merge-option-desc {
+  font-size: 11px;
+  color: var(--text-secondary);
+  line-height: 1.4;
 }
 
 /* ========================================

--- a/app/types/electron.d.ts
+++ b/app/types/electron.d.ts
@@ -327,6 +327,10 @@ export interface ElectronAPI {
   getPRDetail: (prNumber: number) => Promise<PRDetail | null>;
   getPRReviewComments: (prNumber: number) => Promise<PRReviewComment[]>;
   getPRFileDiff: (prNumber: number, filePath: string) => Promise<string | null>;
+  mergePullRequest: (
+    prNumber: number,
+    options?: { method?: 'merge' | 'squash' | 'rebase'; deleteAfterMerge?: boolean }
+  ) => Promise<{ success: boolean; message: string }>;
 }
 
 declare global {

--- a/lib/main/git-service.ts
+++ b/lib/main/git-service.ts
@@ -679,6 +679,62 @@ export async function createPullRequest(options: {
   }
 }
 
+// Merge a pull request
+export type MergeMethod = 'merge' | 'squash' | 'rebase';
+
+export async function mergePullRequest(
+  prNumber: number,
+  options?: {
+    method?: MergeMethod;
+    deleteAfterMerge?: boolean;
+  }
+): Promise<{ success: boolean; message: string }> {
+  if (!repoPath) {
+    return { success: false, message: 'No repository selected' };
+  }
+
+  try {
+    const args = ['pr', 'merge', prNumber.toString()];
+
+    // Add merge method
+    const method = options?.method || 'merge';
+    args.push(`--${method}`);
+
+    // Delete branch after merge (default: true)
+    if (options?.deleteAfterMerge !== false) {
+      args.push('--delete-branch');
+    }
+
+    // Non-interactive
+    args.push('--yes');
+
+    await execAsync(`gh ${args.join(' ')}`, { cwd: repoPath });
+
+    return {
+      success: true,
+      message: `Pull request #${prNumber} merged successfully`
+    };
+  } catch (error) {
+    const errorMessage = (error as Error).message;
+
+    // Check for common errors
+    if (errorMessage.includes('not mergeable')) {
+      return { success: false, message: 'Pull request is not mergeable. Check for conflicts or required checks.' };
+    }
+    if (errorMessage.includes('not logged')) {
+      return { success: false, message: 'Not logged into GitHub CLI. Run `gh auth login` in terminal.' };
+    }
+    if (errorMessage.includes('MERGED')) {
+      return { success: false, message: 'Pull request has already been merged.' };
+    }
+    if (errorMessage.includes('CLOSED')) {
+      return { success: false, message: 'Pull request is closed.' };
+    }
+
+    return { success: false, message: errorMessage };
+  }
+}
+
 // ========================================
 // PR Review Types and Functions
 // ========================================

--- a/lib/main/main.ts
+++ b/lib/main/main.ts
@@ -45,6 +45,7 @@ import {
   getPRDetail,
   getPRReviewComments,
   getPRFileDiff,
+  mergePullRequest,
 } from './git-service'
 import { getLastRepoPath, saveLastRepoPath } from './settings-service'
 
@@ -392,6 +393,14 @@ app.whenReady().then(() => {
       return await getPRFileDiff(prNumber, filePath);
     } catch (error) {
       return null;
+    }
+  });
+
+  ipcMain.handle('merge-pull-request', async (_, prNumber: number, options?: { method?: 'merge' | 'squash' | 'rebase'; deleteAfterMerge?: boolean }) => {
+    try {
+      return await mergePullRequest(prNumber, options);
+    } catch (error) {
+      return { success: false, message: (error as Error).message };
     }
   });
 

--- a/lib/preload/preload.ts
+++ b/lib/preload/preload.ts
@@ -58,6 +58,8 @@ const electronAPI = {
   getPRDetail: (prNumber: number) => ipcRenderer.invoke('get-pr-detail', prNumber),
   getPRReviewComments: (prNumber: number) => ipcRenderer.invoke('get-pr-review-comments', prNumber),
   getPRFileDiff: (prNumber: number, filePath: string) => ipcRenderer.invoke('get-pr-file-diff', prNumber, filePath),
+  mergePullRequest: (prNumber: number, options?: { method?: 'merge' | 'squash' | 'rebase'; deleteAfterMerge?: boolean }) =>
+    ipcRenderer.invoke('merge-pull-request', prNumber, options),
 }
 
 // Use `contextBridge` APIs to expose APIs to


### PR DESCRIPTION
## Summary
Add the ability to merge pull requests directly from the Focus Mode detail panel. Users can now select from three merge strategies: merge, squash, and rebase.

## What's Changed
- Backend: `mergePullRequest()` function in git-service.ts using `gh pr merge`
- Frontend: Merge button with dropdown menu in PRReviewPanel
- UI: Merge options dropdown with descriptions
- IPC: Full integration through electron main/preload layer

## Test Plan
- Open a pull request in Focus Mode
- Click the Merge button in the detail panel footer
- Select a merge strategy and confirm PR merges successfully