### PR TITLE
feat: Add Gemini CLI (gemini-wt) worktree detection

### DIFF
--- a/docs/worktree-location-conventions.md
+++ b/docs/worktree-location-conventions.md
@@ -41,10 +41,13 @@ This document evaluates 5 conventions and explains Ledger's approach.
 ```
 ~/.cursor/worktrees/{repoName}/{hash}/   # Cursor
 ~/.claude/worktrees/{repoName}/{hash}/   # Claude Code
+~/.gemini/worktrees/{repoName}/{hash}/   # Gemini CLI (gemini-wt)
 ~/conductor/workspaces/{repoName}/{task}/# Conductor
 ```
 
 **Pattern**: `~/.{agent}/worktrees/{repoName}/{context}/`
+
+**Note**: Gemini CLI uses the `gemini-wt` tool for managing parallel worktrees. Branches are typically named `gemini-{timestamp}` or custom names.
 
 | Pros | Cons |
 |------|------|
@@ -212,5 +215,6 @@ For now, Ledger adds `.worktrees/` to the project's `.gitignore` and documents t
 - [git-worktree-runner (gtr)](https://github.com/coderabbitai/git-worktree-runner) - Uses sibling folder convention
 - [Ledger Worktrees Feature](./features/worktrees.md)
 - [Ledger Opinionated Git](./opinionated-git.md) - Includes Leapfrog Stash
+
 
 

--- a/lib/services/worktree/worktree-service.ts
+++ b/lib/services/worktree/worktree-service.ts
@@ -70,6 +70,17 @@ function detectAgent(worktreePath: string): WorktreeAgent {
     return 'claude'
   }
 
+  // Gemini CLI (gemini-wt) uses ~/.gemini/worktrees/{project}/
+  // Branches are typically named gemini-{timestamp} or custom names
+  if (worktreePath.includes('/.gemini/worktrees/') || worktreePath.includes('/gemini-worktrees/')) {
+    return 'gemini'
+  }
+
+  // Junie might use ~/.junie/worktrees/ or similar
+  if (worktreePath.includes('/.junie/worktrees/') || worktreePath.includes('/junie-worktrees/')) {
+    return 'junie'
+  }
+
   // Conductor - runs multiple Claude Code agents in parallel
   // Uses ~/conductor/workspaces/{repo-name}/{task-name}/ pattern
   if (worktreePath.includes('/conductor/workspaces/')) {
@@ -162,7 +173,7 @@ async function getWorktreeCommitMessage(worktreePath: string): Promise<string> {
 }
 
 /**
- * Get directory modification time
+ * Get directory modification time (used for sorting worktrees by creation order)
  */
 async function getDirectoryMtime(dirPath: string): Promise<string> {
   try {
@@ -174,17 +185,137 @@ async function getDirectoryMtime(dirPath: string): Promise<string> {
 }
 
 /**
- * Calculate activity status based on last modified time
+ * Get the most recent file modification time in a worktree
+ * Scans files recursively, respecting .gitignore patterns
+ * This detects activity even when agents make changes not yet tracked by git
  */
-function calculateActivityStatus(lastModified: string): WorktreeActivityStatus {
-  const now = Date.now()
-  const modified = new Date(lastModified).getTime()
-  const diffMinutes = (now - modified) / (1000 * 60)
+async function getLastFileModifiedTime(worktreePath: string): Promise<string> {
+  try {
+    // Use git ls-files to get tracked files, then check their mtimes
+    const trackedResult = await safeExec('git', ['ls-files'], { cwd: worktreePath })
+    const trackedFiles = trackedResult.success ? trackedResult.stdout.split('\n').filter(Boolean) : []
 
-  if (diffMinutes < 5) return 'active' // Modified in last 5 minutes
-  if (diffMinutes < 60) return 'recent' // Modified in last hour
-  if (diffMinutes < 24 * 60) return 'stale' // Modified in last 24 hours
-  return 'unknown' // Older than 24 hours
+    // Get untracked files (respects .gitignore)
+    const untrackedResult = await safeExec('git', ['ls-files', '--others', '--exclude-standard'], { cwd: worktreePath })
+    const untrackedFiles = untrackedResult.success ? untrackedResult.stdout.split('\n').filter(Boolean) : []
+
+    const allFiles = [...trackedFiles, ...untrackedFiles]
+
+    let latestMtime = 0
+
+    // Check file mtimes in batches for efficiency
+    const batchSize = 50
+    for (let i = 0; i < allFiles.length; i += batchSize) {
+      const batch = allFiles.slice(i, i + batchSize)
+      const mtimePromises = batch.map(async (file) => {
+        try {
+          const fullPath = path.join(worktreePath, file)
+          const stat = await statAsync(fullPath)
+          return stat.mtime.getTime()
+        } catch {
+          return 0
+        }
+      })
+      const mtimes = await Promise.all(mtimePromises)
+      const maxInBatch = Math.max(...mtimes, 0)
+      if (maxInBatch > latestMtime) {
+        latestMtime = maxInBatch
+      }
+    }
+
+    return latestMtime > 0 ? new Date(latestMtime).toISOString() : new Date().toISOString()
+  } catch {
+    // Fallback to directory mtime
+    return getDirectoryMtime(worktreePath)
+  }
+}
+
+/**
+ * Get the last git activity time for a worktree
+ * Returns the more recent of: last commit time, or last change to working directory
+ */
+async function getLastGitActivity(worktreePath: string): Promise<string> {
+  try {
+    // Get last commit time
+    let lastCommitTime = 0
+    const commitResult = await safeExec('git', ['log', '-1', '--format=%ct'], { cwd: worktreePath })
+    if (commitResult.success) {
+      const timestamp = parseInt(commitResult.stdout.trim(), 10)
+      if (!isNaN(timestamp)) {
+        lastCommitTime = timestamp * 1000 // Convert to milliseconds
+      }
+    }
+
+    // Check for uncommitted changes and their modification times
+    let lastChangeTime = 0
+    const diffResult = await safeExec('git', ['diff', '--name-only'], { cwd: worktreePath })
+    const stagedResult = await safeExec('git', ['diff', '--staged', '--name-only'], { cwd: worktreePath })
+    const untrackedResult = await safeExec('git', ['ls-files', '--others', '--exclude-standard'], { cwd: worktreePath })
+
+    const changedFiles = [
+      ...(diffResult.success ? diffResult.stdout.split('\n').filter(Boolean) : []),
+      ...(stagedResult.success ? stagedResult.stdout.split('\n').filter(Boolean) : []),
+      ...(untrackedResult.success ? untrackedResult.stdout.split('\n').filter(Boolean) : []),
+    ]
+
+    // Get the most recent mtime of changed files
+    for (const file of changedFiles.slice(0, 20)) { // Limit to 20 files for perf
+      try {
+        const fullPath = path.join(worktreePath, file)
+        const stat = await statAsync(fullPath)
+        if (stat.mtime.getTime() > lastChangeTime) {
+          lastChangeTime = stat.mtime.getTime()
+        }
+      } catch {
+        // File might have been deleted
+      }
+    }
+
+    // Return the more recent of commit time or change time
+    const latestActivity = Math.max(lastCommitTime, lastChangeTime)
+    return latestActivity > 0 ? new Date(latestActivity).toISOString() : new Date().toISOString()
+  } catch {
+    return new Date().toISOString()
+  }
+}
+
+/**
+ * Calculate activity status based on both file and git activity
+ * Uses the more recent of the two signals
+ */
+function calculateActivityStatus(
+  lastFileModified: string,
+  lastGitActivity: string
+): { status: WorktreeActivityStatus; source: 'file' | 'git' | 'both' } {
+  const now = Date.now()
+  const fileModified = new Date(lastFileModified).getTime()
+  const gitActivity = new Date(lastGitActivity).getTime()
+
+  // Use the more recent activity
+  const moreRecent = Math.max(fileModified, gitActivity)
+  const diffMinutes = (now - moreRecent) / (1000 * 60)
+
+  // Determine which source is more recent
+  let source: 'file' | 'git' | 'both' = 'both'
+  const timeDiff = Math.abs(fileModified - gitActivity)
+  const significantDiff = 60 * 1000 // 1 minute threshold
+  
+  if (timeDiff > significantDiff) {
+    source = fileModified > gitActivity ? 'file' : 'git'
+  }
+
+  let status: WorktreeActivityStatus
+  if (diffMinutes < 5) {
+    status = 'active' // Modified in last 5 minutes
+  } else if (diffMinutes < 60) {
+    status = 'recent' // Modified in last hour
+  } else if (diffMinutes < 24 * 60) {
+    status = 'stale' // Modified in last 24 hours
+  } else {
+    status = 'unknown' // Older than 24 hours
+  }
+
+  return { status, source }
 }
 
 /**
@@ -258,6 +389,83 @@ async function getCursorAgentTaskHint(worktreePath: string): Promise<string | nu
 }
 
 /**
+ * Get agent task hint from Claude Code session files
+ * Claude Code stores sessions in ~/.claude/projects/{encoded-path}/*.jsonl
+ */
+async function getClaudeCodeAgentTaskHint(worktreePath: string): Promise<string | null> {
+  try {
+    const homeDir = process.env.HOME || ''
+    const projectsDir = path.join(homeDir, '.claude', 'projects')
+
+    // Check if the projects directory exists
+    if (!fs.existsSync(projectsDir)) return null
+
+    // Claude Code encodes paths by replacing / with - (e.g., /Users/foo/bar -> -Users-foo-bar)
+    const encodedPath = worktreePath.replace(/\//g, '-')
+    const projectFolder = path.join(projectsDir, encodedPath)
+
+    // Check if this worktree has a Claude Code project folder
+    if (!fs.existsSync(projectFolder)) return null
+
+    // Get session files sorted by modification time (newest first)
+    // Session files are UUIDs.jsonl, skip agent-*.jsonl files
+    const files = fs
+      .readdirSync(projectFolder)
+      .filter((f) => f.endsWith('.jsonl') && !f.startsWith('agent-'))
+      .map((f) => ({
+        name: f,
+        path: path.join(projectFolder, f),
+        mtime: fs.statSync(path.join(projectFolder, f)).mtime.getTime(),
+      }))
+      .sort((a, b) => b.mtime - a.mtime)
+
+    // Check the most recent session file
+    for (const file of files.slice(0, 3)) {
+      // Only check 3 most recent sessions
+      try {
+        const content = fs.readFileSync(file.path, 'utf-8')
+        const lines = content.split('\n').filter(Boolean)
+
+        // Find the first user message in the session
+        for (const line of lines) {
+          try {
+            const entry = JSON.parse(line)
+
+            // Look for user messages
+            if (entry.type === 'user' && entry.message?.content) {
+              let userContent = entry.message.content
+
+              // Strip system instruction tags if present
+              userContent = userContent.replace(/<system[_-]?instruction>[\s\S]*?<\/system[_-]?instruction>/gi, '')
+
+              // Get the actual user query, trimming whitespace
+              const trimmed = userContent.trim()
+              if (!trimmed) continue
+
+              // Get first meaningful line
+              const firstLine = trimmed.split('\n')[0].trim()
+              if (!firstLine) continue
+
+              return firstLine.slice(0, 60) + (firstLine.length > 60 ? '…' : '')
+            }
+          } catch {
+            // Skip malformed lines
+            continue
+          }
+        }
+      } catch {
+        // Skip unreadable files
+        continue
+      }
+    }
+
+    return null
+  } catch {
+    return null
+  }
+}
+
+/**
  * Get enhanced worktrees with agent detection and metadata
  */
 export async function getEnhancedWorktrees(ctx: RepositoryContext): Promise<EnhancedWorktree[]> {
@@ -269,15 +477,19 @@ export async function getEnhancedWorktrees(ctx: RepositoryContext): Promise<Enha
     const agent = detectAgent(wt.path)
 
     // Gather all metadata in parallel
-    const [diffStats, commitMessage, lastModified, agentTaskHint] = await Promise.all([
+    const [diffStats, commitMessage, lastModified, lastFileModified, lastGitActivity, agentTaskHint] = await Promise.all([
       getWorktreeDiffStats(wt.path),
       getWorktreeCommitMessage(wt.path),
       getDirectoryMtime(wt.path),
-      agent === 'cursor' ? getCursorAgentTaskHint(wt.path) : Promise.resolve(null),
+      getLastFileModifiedTime(wt.path),
+      getLastGitActivity(wt.path),
+      agent === 'cursor' ? getCursorAgentTaskHint(wt.path) :
+      agent === 'claude' ? getClaudeCodeAgentTaskHint(wt.path) :
+      Promise.resolve(null),
     ])
 
     const contextHint = getContextHint(wt.branch, diffStats.changedFiles, commitMessage)
-    const activityStatus = calculateActivityStatus(lastModified)
+    const { status: activityStatus, source: activitySource } = calculateActivityStatus(lastFileModified, lastGitActivity)
 
     return {
       ...wt,
@@ -290,6 +502,9 @@ export async function getEnhancedWorktrees(ctx: RepositoryContext): Promise<Enha
       deletions: diffStats.deletions,
       lastModified,
       activityStatus,
+      lastFileModified,
+      lastGitActivity,
+      activitySource,
       agentTaskHint,
     }
   })


### PR DESCRIPTION
## Summary

Adds support for detecting Gemini CLI worktrees in Ledger's worktree management tooling.

## Changes

- Add `~/.gemini/worktrees/` and `/gemini-worktrees/` patterns to `detectAgent` function
- Sync detection logic between `worktree-service.ts` and `git-service.ts`
- Add Junie detection to `worktree-service.ts` for consistency
- Update `worktree-location-conventions.md` with gemini-wt details

## Background

**Gemini CLI** uses the `gemini-wt` tool for managing parallel worktrees:
- Worktrees are stored at `~/.gemini/worktrees/{project}/`
- Branches are typically named `gemini-{timestamp}` or custom names
- Each session operates in an isolated Git worktree

## Files Changed

- `lib/services/worktree/worktree-service.ts` - Added Gemini and Junie detection
- `lib/main/git-service.ts` - Updated Gemini detection with fallback pattern
- `docs/worktree-location-conventions.md` - Added Gemini CLI documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances worktree intelligence and Git utilities across services.
> 
> - Adds Gemini CLI (`~/.gemini/worktrees/` and `/gemini-worktrees/`) detection; also includes Junie pattern in service layer
> - Introduces dual-source activity tracking: computes `lastFileModified`, `lastGitActivity`, and `activitySource`; `calculateActivityStatus` now uses the more recent signal
> - Extends `getEnhancedWorktrees` to populate new fields and fetch agent task hints for Claude Code sessions; keeps Cursor transcript parsing
> - New Git helpers: `renameBranch(oldName, newName)` with validations and `getBehindMainCount()` to report commits behind `main/master`
> - Updates docs to document Gemini CLI worktree convention and notes on branch naming
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1093f24a47e6beace9ef8206b92bd13af78dbc3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->