### PR TITLE
Fix: Include worktree branches in unmerged branch list

### DIFF
--- a/lib/main/git-service.ts
+++ b/lib/main/git-service.ts
@@ -112,7 +112,7 @@ export async function getUnmergedBranches(baseBranch: string = 'origin/master'):
     const result = await git.raw(['branch', '-a', '--no-merged', targetBranch])
     return result
       .split('\n')
-      .map((b) => b.trim().replace(/^\* /, ''))
+      .map((b) => b.trim().replace(/^[*+]\s*/, '')) // Strip * (current) or + (checked out in worktree) markers
       .filter((b) => b && !b.includes('HEAD'))
   } catch {
     return []


### PR DESCRIPTION
## Summary
- Fixed regex in `getUnmergedBranches()` to strip both `*` (current branch) and `+` (worktree branch) markers from `git branch` output
- Previously, branches checked out in worktrees were incorrectly parsed because they have a `+` prefix instead of `*`

## Context
When a branch is checked out in a worktree, `git branch` marks it with `+` instead of `*`:
```
  feature-a
+ feature-b-in-worktree
* current-branch
```

The old regex `/^\* /` only stripped the `*` marker, causing branches like `+ feature-b` to fail matching and not appear in the unmerged branches list.

## Test plan
- [x] Verify branches checked out in worktrees appear correctly in the unmerged branches filter
- [x] Lint check passes (no new errors)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures unmerged branch detection includes branches checked out in worktrees.
> 
> - Updates `getUnmergedBranches()` in `lib/main/git-service.ts` to strip both `*` (current) and `+` (worktree) markers from `git branch` output via regex `^[*+]\s*`
> - Prevents missing worktree-checked-out branches in the unmerged list
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1cc8d5210c53ae656d365cc5ac44da3be1c288b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->