### PR TITLE
a11y: add focus-visible styling for meta-value-link

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -2185,6 +2185,12 @@ body,
   text-decoration: underline;
 }
 
+.meta-value-link:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+
 .meta-value-link .branch-icon {
   font-size: 10px;
   opacity: 0.7;


### PR DESCRIPTION
## Summary

- Adds `focus-visible` outline styling to `.meta-value-link` elements
- Improves keyboard navigation accessibility by showing a visible focus indicator
- Uses existing `--accent` CSS variable for consistency

## Test plan

- [ ] Tab through meta-value-link elements with keyboard
- [ ] Verify focus outline appears with 2px accent-colored border
- [ ] Verify no visual change when using mouse (focus-visible, not focus)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves keyboard accessibility by adding a visible focus indicator to branch/meta links.
> 
> - Adds `:focus-visible` styles for `.meta-value-link` (2px `--accent` outline, 2px offset, 6px radius)
> - No other files or behaviors changed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4c8aef34e98e3236fe8b5ab889ff563d3a59eaf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->